### PR TITLE
Prevent setting either frame dimension to 0

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -970,6 +970,14 @@ impl Session {
                 }
             }
             Command::ResizeFrame(fw, fh) => {
+                if fw == 0 || fh == 0 {
+                    self.message(
+                        "Error: cannot set frame dimension to `0`",
+                        MessageType::Error,
+                    );
+                    return;
+                }
+
                 let v = self.active_view_mut();
                 v.resize_frame(fw, fh);
                 v.touch();


### PR DESCRIPTION
This prevents the user from setting either dimension to a size of `0` which is invalid and will currently crash the program.

---

Side note: I love this project so far!