### PR TITLE
Avoid running unmatched key release bindings after mode switch

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -1148,7 +1148,8 @@ impl Session {
             _ => {}
         }
 
-        let pressed: Vec<platform::Key> = self.keys_pressed.drain().collect();
+        let pressed: Vec<platform::Key> =
+            self.keys_pressed.iter().cloned().collect();
         for k in pressed {
             self.handle_keyboard_input(platform::KeyboardInput {
                 key: Some(k),
@@ -1856,7 +1857,9 @@ impl Session {
             if state == InputState::Pressed {
                 self.keys_pressed.insert(key);
             } else if state == InputState::Released {
-                self.keys_pressed.remove(&key);
+                if !self.keys_pressed.remove(&key) {
+                    return;
+                }
             }
 
             match self.mode {


### PR DESCRIPTION
This PR implements the solution described in issue #11, [this comment](https://github.com/cloudhead/rx/issues/11#issuecomment-527168260).
Tested manually, works fine for me.