### PR TITLE
Platform-independent support for toggle-like key bindings

### DIFF
--- a/src/platform/glfw.rs
+++ b/src/platform/glfw.rs
@@ -170,7 +170,6 @@ impl From<glfw::WindowEvent> for WindowEvent {
                     key: Some(key.into()),
                     state: action.into(),
                     modifiers: modifiers.into(),
-                    repeat: action == glfw::Action::Repeat,
                 })
             }
             Glfw::Focus(b) => WindowEvent::Focused(b),

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -99,7 +99,6 @@ pub struct KeyboardInput {
     pub state: InputState,
     pub key: Option<Key>,
     pub modifiers: ModifiersState,
-    pub repeat: bool,
 }
 
 /// Describes the input state of a key.

--- a/src/platform/winit.rs
+++ b/src/platform/winit.rs
@@ -112,8 +112,6 @@ impl From<winit::event::KeyboardInput> for KeyboardInput {
             state: input.state.into(),
             key: input.virtual_keycode.map(Key::from),
             modifiers: input.modifiers.into(),
-            // NOTE: winit currently doesn't support this.
-            repeat: false,
         }
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1167,7 +1167,6 @@ impl Session {
                 key: Some(k),
                 modifiers: ModifiersState::default(),
                 state: InputState::Released,
-                repeat: false,
             });
         }
 
@@ -1857,8 +1856,10 @@ impl Session {
             state,
             modifiers,
             key,
-            repeat,
+            ..
         } = input;
+
+        let mut repeat = false;
 
         if let Some(key) = key {
             // While the mouse is down, don't accept keyboard input.
@@ -1867,7 +1868,7 @@ impl Session {
             }
 
             if state == InputState::Pressed {
-                self.keys_pressed.insert(key);
+                repeat = !self.keys_pressed.insert(key);
             } else if state == InputState::Released {
                 if !self.keys_pressed.remove(&key) {
                     return;


### PR DESCRIPTION
This should work on any platform. I need it because I am stuck on winit, as glfw doesn't read correctly key combinations for me (e.g. `<shift>+.` on my layout should be a colon and enter command line, but under glfw only separate events for shift and dot are processed, so it just zooms in. Not sure why, maybe I should open an issue?)