### PR TITLE
Convert ~ character into the user's home directory path

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -25,6 +25,7 @@ use std::ops::{Add, Deref, Sub};
 use std::path::Path;
 use std::str::FromStr;
 use std::time;
+use std::ffi::OsString;
 
 /// Help string.
 pub const HELP: &'static str = r#"
@@ -1072,6 +1073,34 @@ impl Session {
         self.view_coords(self.views.active_id, p)
     }
 
+    /// Expand paths, e.g. by converting ~ into the user's home directory path
+    pub fn expand_path<P: AsRef<Path>>(&mut self, path: P) -> OsString {
+            let mut path = path.as_ref();
+
+            // for Linux and BSD and MacOS
+            if cfg!(unix) && path.starts_with("~") {
+
+                // ensure that the base directory list can be loaded by
+                // ensuring it has at least one element
+                if let Some(base_dirs) = dirs::BaseDirs::new() {
+
+                    // alloc space + store a copy of home directory as an
+                    // OsString, which are easily used with Path::new()
+                    let home = base_dirs.home_dir().as_os_str().to_os_string();
+
+                    if path == Path::new("~") {
+                        return home;
+                    }
+
+                    path = &path.strip_prefix("~").unwrap();
+                    return Path::new(&home).join(path).into_os_string();
+                }
+            }
+
+            // for Windows and other platforms
+            path.as_os_str().to_os_string()
+    }
+
     /// Edit paths.
     ///
     /// Loads the given files into the session. Returns an error if one of
@@ -1082,7 +1111,8 @@ impl Session {
     pub fn edit<P: AsRef<Path>>(&mut self, paths: &[P]) -> io::Result<()> {
         // TODO: Keep loading paths even if some fail?
         for path in paths {
-            let path = path.as_ref();
+            let path_osstring = &self.expand_path(path);
+            let path = Path::new(path_osstring);
 
             if path.is_dir() {
                 for entry in fs::read_dir(path)? {
@@ -1118,7 +1148,9 @@ impl Session {
     /// an error if the view has no file name.
     pub fn save_view(&mut self, id: ViewId) -> io::Result<()> {
         if let Some(ref f) = self.view(id).file_name().map(|f| f.clone()) {
-            self.save_view_as(id, f)
+            let path_osstring = &self.expand_path(f);
+            let path = Path::new(path_osstring);
+            self.save_view_as(id, path)
         } else {
             Err(io::Error::new(io::ErrorKind::Other, "no file name given"))
         }
@@ -1131,6 +1163,7 @@ impl Session {
         id: ViewId,
         path: P,
     ) -> io::Result<()> {
+
         let ext = path.as_ref().extension().ok_or(io::Error::new(
             io::ErrorKind::Other,
             "file path requires an extension (.gif or .png)",
@@ -1547,7 +1580,8 @@ impl Session {
     /// Source an rx script at the given path. Returns an error if the path
     /// does not exist or the script couldn't be sourced.
     fn source_path<P: AsRef<Path>>(&mut self, path: P) -> io::Result<()> {
-        let path = path.as_ref();
+        let path_osstring = &self.expand_path(path);
+        let path = Path::new(path_osstring);
         debug!("source: {}", path.display());
 
         let f = File::open(&path)
@@ -2027,6 +2061,8 @@ impl Session {
                 }
             }
             Command::Write(Some(ref path)) => {
+                let path_osstring = &self.expand_path(path);
+                let path = Path::new(path_osstring);
                 if let Err(e) = self.save_view_as(self.views.active_id, path) {
                     self.message(format!("Error: {}", e), MessageType::Error);
                 }


### PR DESCRIPTION
On various Unix-like operating systems, the `~` character is a abbreviation for home directory path; typically something like: /home/jsmith/

Since Vim auto-expands the path in such as way, and the goal of this project is to be Vim-like, I figure adding this piece of functionality would be helpful for those of us using such operating systems.

I implement this through the creation of an OsString function that will expand the path and combines it using the `join()` function. This function is then called to expand the path in the save, load, source and write routines; which I believe are all the logic that needs to open or write files (but feel free to correct me if I am mistaken).

Hope this changeset is in the spirit of your project, and let me know what you think :)