### PR TITLE
Add cmake to build dependencies section

### DIFF
--- a/README
+++ b/README
@@ -66,6 +66,7 @@ PLATFORM SUPPORT
 BUILD DEPENDENCIES
 
   * rust (https://www.rust-lang.org/tools/install)
+  * cmake (https://cmake.org/download/)
 
   macOS
 


### PR DESCRIPTION
The build dependencies section in the README doesn't list cmake, even though cmake is required to build one of the crates in the dependency tree (glfw-sys).