### PR TITLE
Add functionality to let the user set the background color

### DIFF
--- a/config/init.rx
+++ b/config/init.rx
@@ -35,6 +35,7 @@ set checker = off                                             --  Turn off alpha
 set debug = off                                               --  Turn off debug mode
 set vsync = off                                               --  Turn off Vsync
 set input/delay = 8.0                                         --  Set frame delay to 8 milliseconds
+set background = #000000                                      --  Set background appearance to black
 
 brush/set perfect                                             --  Set brush to "pixel-perfect" mode
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -44,6 +44,7 @@ pub enum Command {
     CloneFrame(i32),
     RemoveFrame,
     Noop,
+    BackgroundColor(Rgba8),
     PaletteAdd(Rgba8),
     PaletteClear,
     PaletteSample,
@@ -105,6 +106,9 @@ impl fmt::Display for Command {
             }
             Self::RemoveFrame => write!(f, "Remove the last frame of the view"),
             Self::Noop => write!(f, "No-op"),
+            Self::BackgroundColor(c) => {
+                write!(f, "Set the UI background appearance to {color}", color = c)
+            }
             Self::PaletteAdd(c) => {
                 write!(f, "Add {color} to palette", color = c)
             }
@@ -273,6 +277,13 @@ impl Value {
             return *n as u64;
         }
         panic!("expected {:?} to be a `uint`", self);
+    }
+
+    pub fn color(&self) -> Rgba8 {
+        if let Value::Rgba8(rgba8) = self {
+            return *rgba8 as Rgba8;
+        }
+        panic!("expected {:?} to be a `Rgba8`", self);
     }
 
     pub fn description(&self) -> &'static str {
@@ -517,6 +528,10 @@ impl<'a> Parse<'a> for Command {
             "brush/unset" => {
                 let (mode, p) = p.parse::<BrushMode>()?;
                 Ok((Command::BrushUnset(mode), p))
+            }
+            "background/set" => {
+                let (rgba, p) = p.parse::<Rgba8>()?;
+                Ok((Command::BackgroundColor(rgba), p))
             }
             "mode" => {
                 let (mode, p) = p.parse::<Mode>()?;

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -44,7 +44,6 @@ pub enum Command {
     CloneFrame(i32),
     RemoveFrame,
     Noop,
-    BackgroundColor(Rgba8),
     PaletteAdd(Rgba8),
     PaletteClear,
     PaletteSample,
@@ -106,9 +105,6 @@ impl fmt::Display for Command {
             }
             Self::RemoveFrame => write!(f, "Remove the last frame of the view"),
             Self::Noop => write!(f, "No-op"),
-            Self::BackgroundColor(c) => {
-                write!(f, "Set the UI background appearance to {color}", color = c)
-            }
             Self::PaletteAdd(c) => {
                 write!(f, "Add {color} to palette", color = c)
             }
@@ -281,7 +277,7 @@ impl Value {
 
     pub fn color(&self) -> Rgba8 {
         if let Value::Rgba8(rgba8) = self {
-            return *rgba8 as Rgba8;
+            return *rgba8;
         }
         panic!("expected {:?} to be a `Rgba8`", self);
     }
@@ -528,10 +524,6 @@ impl<'a> Parse<'a> for Command {
             "brush/unset" => {
                 let (mode, p) = p.parse::<BrushMode>()?;
                 Ok((Command::BrushUnset(mode), p))
-            }
-            "background/set" => {
-                let (rgba, p) = p.parse::<Rgba8>()?;
-                Ok((Command::BackgroundColor(rgba), p))
             }
             "mode" => {
                 let (mode, p) = p.parse::<Mode>()?;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -530,7 +530,8 @@ impl Renderer {
 
         {
             // Present screen framebuffer to screen.
-            let mut p = f.pass(PassOp::Clear(Rgba::TRANSPARENT), present);
+            let background_appearance_color = Rgba::from(session.settings["background"].color());
+            let mut p = f.pass(PassOp::Clear(background_appearance_color), present);
 
             p.set_pipeline(&self.screen2d);
             p.set_binding(&self.screen_binding, &[]);

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -530,8 +530,8 @@ impl Renderer {
 
         {
             // Present screen framebuffer to screen.
-            let background_appearance_color = Rgba::from(session.settings["background"].color());
-            let mut p = f.pass(PassOp::Clear(background_appearance_color), present);
+            let bg = Rgba::from(session.settings["background"].color());
+            let mut p = f.pass(PassOp::Clear(bg), present);
 
             p.set_pipeline(&self.screen2d);
             p.set_binding(&self.screen_binding, &[]);

--- a/src/session.rs
+++ b/src/session.rs
@@ -541,9 +541,6 @@ pub struct Session {
     /// The current session `State`.
     pub state: State,
 
-    /// The background appearance color of the UI.
-    pub background: Rgba8,
-
     /// The width of the session workspace.
     pub width: f32,
     /// The height of the session workspace.
@@ -687,7 +684,6 @@ impl Session {
             state: State::Initializing,
             width: w as f32,
             height: h as f32,
-            background: color::BLACK,
             hidpi_factor,
             cursor: SessionCoords::new(0., 0.),
             base_dirs,

--- a/src/session.rs
+++ b/src/session.rs
@@ -56,13 +56,14 @@ pub const HELP: &'static str = r#"
 
 SETTINGS
 
-debug             on/off        Debug mode
-checker           on/off        Alpha checker toggle
-vsync             on/off        Vertical sync toggle
-input/delay       0.0..32.0     Delay between render frames (ms)
-scale             1.0..4.0      UI scale
-animation         on/off        View animation toggle
-animation/delay   1..1000       View animation delay (ms)
+debug             on/off             Debug mode
+checker           on/off             Alpha checker toggle
+vsync             on/off             Vertical sync toggle
+input/delay       0.0..32.0          Delay between render frames (ms)
+scale             1.0..4.0           UI scale
+animation         on/off             View animation toggle
+animation/delay   1..1000            View animation delay (ms)
+background        #000000..#ffffff   Set background appearance to <color>, eg. #ff0011
 "#;
 
 /// An RGB 8-bit color. Used when the alpha value isn't used.
@@ -505,6 +506,7 @@ impl Default for Settings {
             map: hashmap! {
                 "debug" => Value::Bool(false),
                 "checker" => Value::Bool(false),
+                "background" => Value::Rgba8(color::BLACK),
                 "vsync" => Value::Bool(false),
                 "input/delay" => Value::Float(8.0),
                 "scale" => Value::Float(1.0),
@@ -538,6 +540,9 @@ pub struct Session {
     pub mode: Mode,
     /// The current session `State`.
     pub state: State,
+
+    /// The background appearance color of the UI.
+    pub background: Rgba8,
 
     /// The width of the session workspace.
     pub width: f32,
@@ -682,6 +687,7 @@ impl Session {
             state: State::Initializing,
             width: w as f32,
             height: h as f32,
+            background: color::BLACK,
             hidpi_factor,
             cursor: SessionCoords::new(0., 0.),
             base_dirs,


### PR DESCRIPTION
As per issue #17, this allows the user set the background color of rx using the following command or config file entry:

```
set background = #000000 
```

Where `#000000` is an Rgba8 color, and the default color is black. In addition, I have added an entry to the default init.rx script to detail exactly how to set the color using scripts.

Some quick testing suggest it works on startup and with animation mode, although admittedly most colors do not look good; however a few of the grey shades, notably `#222222` and `#303030`, are fairly decent.