### PR TITLE
Utilize canonicalize() to expand . and .. characters in Paths

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -212,9 +212,11 @@ impl<'a> Parser<'a> {
 
     pub fn path(self) -> Result<'a, String> {
         let (path, parser) = self.word()?;
-        let mut path = Path::new(path);
 
-        // For Linux and BSD and MacOS.
+        let path = Path::new(path);
+        let mut path_string = String::from(path.to_str().unwrap());
+
+        // Linux and BSD and MacOS use ~ to infer the home directory of a given user
         if cfg!(unix) && path.starts_with("~") {
             if let Some(base_dirs) = dirs::BaseDirs::new() {
                 let home = base_dirs.home_dir().to_str().unwrap().to_owned();
@@ -223,16 +225,38 @@ impl<'a> Parser<'a> {
                     return Ok((home, parser));
                 }
 
-                path = &path.strip_prefix("~").unwrap();
-                return Ok((
-                    Path::new(&home).join(path).to_str().unwrap().to_owned(),
-                    parser,
-                ));
+                let suffix = path.strip_prefix("~").unwrap();
+                path_string = Path::new(&home).join(suffix).to_str().unwrap().to_owned();
             }
         }
 
-        // For Windows and other platforms.
-        Ok((path.to_str().unwrap().to_owned(), parser))
+        let filename = match Path::new(&path_string).file_name().is_none() {
+            true => String::from(""),
+            false => Path::new(&path_string).file_name().unwrap().to_str().unwrap().to_owned(),
+        };
+
+        let directory = match Path::new(&path_string).parent().is_none() {
+            true => String::from(""),
+            false => Path::new(&path_string).parent().unwrap().to_str().unwrap().to_owned(),
+        };
+
+        let canonical_directory = match Path::new(&directory).canonicalize().is_err() {
+            true => String::from(""),
+            false => Path::new(&directory).canonicalize().unwrap().to_str().unwrap().to_owned(),
+        };
+
+        let path_str = match directory == "" || canonical_directory == "" {
+
+            // if directory or canonical directory string is empty or an
+            // error occurred, default to simply attempting to use the original
+            // non-canonical path as a last resort
+            true => Path::new(path).to_str().unwrap().to_owned(),
+
+            // otherwise the path likely canonicalized correctly, so use that
+            false => Path::new(&canonical_directory).join(Path::new(&filename)).to_str().unwrap().to_owned(),
+        };
+
+        Ok((path_str.to_string(), parser))
     }
 
     pub fn peek(&self) -> Option<char> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -237,11 +237,11 @@ impl<'a> Parser<'a> {
         }
 
         match path.to_str() {
-            Some(path_as_str) => {
-                Ok((path_as_str.to_string(), parser))
+            Some(p) => {
+                Ok((p.to_string(), parser))
             },
             None => {
-                Err(Error::new(format!("unable to convert Path into a String: `{:?}`", path)))
+                Err(Error::new(format!("invalid path: {:?}", path)))
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -214,6 +214,10 @@ impl<'a> Parser<'a> {
         let (path, parser) = self.word()?;
 
         let path = Path::new(path);
+        if path.to_str().is_none() {
+            return Ok((String::from(""), parser));
+        }
+
         let mut path_string = String::from(path.to_str().unwrap());
 
         // Linux and BSD and MacOS use ~ to infer the home directory of a given user
@@ -234,7 +238,7 @@ impl<'a> Parser<'a> {
             .and_then(|directory| directory.canonicalize().ok());
 
         if let (Some(directory), Some(filename)) = (directory, &Path::new(&path_string).file_name()) {
-            path_string = Path::new(&directory).join(Path::new(&filename)).to_str().unwrap().to_string()
+            path_string = Path::new(&directory).join(Path::new(&filename)).to_str().unwrap().to_string();
         }
 
         Ok((path_string, parser))

--- a/src/session.rs
+++ b/src/session.rs
@@ -1153,13 +1153,13 @@ impl Session {
                         continue;
                     }
 
-                    // TODO: i think an error occurs here which causes
-                    // the `:e /tmp/` command to crash the program
                     self.load_view(path)?;
                 }
                 self.source_dir(path).ok();
             } else if path.exists() {
                 self.load_view(path)?;
+            } else if !path.exists() && path.with_extension("png").exists() {
+                self.load_view(path.with_extension("png"))?;
             } else {
                 let (w, h) = if !self.views.is_empty() {
                     let v = self.active_view();

--- a/src/session.rs
+++ b/src/session.rs
@@ -1135,15 +1135,6 @@ impl Session {
         for path in paths {
             let path = path.as_ref();
 
-            // by this point the path should be canonicalized, so the path
-            // should not end with a period character
-            if path.to_str().unwrap().ends_with(".") {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    format!("`{:?}` is not a valid filename", path),
-                ));
-            }
-
             if path.is_dir() {
                 for entry in path.read_dir()? {
                     let entry = entry?;

--- a/src/session.rs
+++ b/src/session.rs
@@ -1135,6 +1135,21 @@ impl Session {
         for path in paths {
             let path = path.as_ref();
 
+            let ext = path.extension().ok_or(io::Error::new(
+                io::ErrorKind::Other,
+                "file path requires an extension (.gif or .png)",
+            ))?;
+            let ext = ext.to_str().ok_or(io::Error::new(
+                io::ErrorKind::Other,
+                "file extension is not valid unicode",
+            ))?;
+            if !Self::SUPPORTED_FORMATS.contains(&ext) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("`{}` is not a supported output format", ext),
+                ));
+            }
+
             if path.is_dir() {
                 for entry in fs::read_dir(path)? {
                     let entry = entry?;


### PR DESCRIPTION
As per issue #34, this pull request uses the `canonicalize()` function to handle and resolve `.` and `..` characters 

The canonicalize functionality of Rust is a bit tricky and has (possibly?) [differing behavior between the OSes](https://doc.rust-lang.org/std/fs/fn.canonicalize.html) and requires a number of careful checks to ensure that errors do not normally occur (since `canonicalize()` will throw errors if a folder or file does not exist, etc), along with some testing to confirm that even complicated paths like `/tmp/./../tmp/abc.png` work safely.

As a last resort if some or all of the canonalization logic causes errors or empty strings, then the default is to try the original non-canonicalized path.

Please note I only really tested this on Linux, so feel free to test it on MacOS or Windows if you have them.