### PR TITLE
If applied, this commit will stop some configs from panicking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,8 +124,13 @@ pub fn init<P: AsRef<Path>>(paths: &[P], options: Options) -> std::io::Result<()
     let resources = ResourceManager::new();
     let base_dirs = dirs::ProjectDirs::from("io", "cloudhead", "rx")
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "home directory not found"))?;
-    let mut session =
-        Session::new(win_w, win_h, resources.clone(), base_dirs).init(options.source.clone())?;
+    let mut session = Session::new(win_w, win_h, resources.clone(), base_dirs)
+        .with_blank(
+            FileStatus::NoFile,
+            Session::DEFAULT_VIEW_W,
+            Session::DEFAULT_VIEW_H,
+        )
+        .init(options.source.clone())?;
 
     if options.debug {
         session
@@ -183,13 +188,6 @@ pub fn init<P: AsRef<Path>>(paths: &[P], options: Options) -> std::io::Result<()
 
     if let Err(e) = session.edit(paths) {
         session.message(format!("Error loading path(s): {}", e), MessageType::Error);
-    }
-    if session.views.is_empty() {
-        session.blank(
-            FileStatus::NoFile,
-            Session::DEFAULT_VIEW_W,
-            Session::DEFAULT_VIEW_H,
-        );
     }
 
     renderer.init(session.effects(), &session.views);

--- a/src/session.rs
+++ b/src/session.rs
@@ -885,6 +885,12 @@ impl Session {
         self.edit_view(id);
     }
 
+    pub fn with_blank(mut self, fs: FileStatus, w: u32, h: u32) -> Self {
+        self.blank(fs, w, h);
+
+        self
+    }
+
     /// Transition to a new state. Only allows valid state transitions.
     pub fn transition(&mut self, to: State) {
         match (&self.state, &to) {


### PR DESCRIPTION
Some config options previously raised a panic of the following form:

	thread 'main' panicked at 'fatal: no active view', src/session.rs:1293:9
	note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.

The config commands in question include:

* f/resize
* set animation/delay
* slice

Fixes #51

---

# TODO:

I'm not sure if these are worth doing, but I'm aware they're potential issues:

- [ ] Add automated tests
- [ ] Move the `session.blank(...)` call to `Session::new(...)` to simplify `fn init(...)` in `lib.rs`.