### PR TITLE
If applied this commit will add :wq and :x commands

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -520,6 +520,7 @@ impl<'a> Parse<'a> for Command {
             "qa" => Ok((Command::QuitAll, p)),
             "q!" => Ok((Command::ForceQuit, p)),
             "qa!" => Ok((Command::ForceQuitAll, p)),
+            "wq" | "x" => Ok((Command::WriteQuit, p)),
             "w" => {
                 if p.is_empty() {
                     Ok((Command::Write(None), p))


### PR DESCRIPTION
The codebase had all of the support for the WriteQuit command
but it wasn't being invoked in cmd.rs so this was probably an oversight.