### PR TITLE
added the `--man` subcommand

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -706,6 +706,7 @@ impl Default for Commands {
             .command("e/frames", "Edit frames as view", |p| {
                 p.then(paths()).map(|(_, paths)| Command::EditFrames(paths))
             })
+            .command("h", "Display help", |p| p.value(Command::Mode(Mode::Help)))
             .command("help", "Display help", |p| {
                 p.value(Command::Mode(Mode::Help))
             })

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -764,14 +764,7 @@ pub fn draw_help(session: &Session, text: &mut TextBatch, shape: &mut shape2d::B
         TextAlign::Left,
     );
 
-    let (normal_kbs, visual_kbs): (
-        Vec<(&String, &session::KeyBinding)>,
-        Vec<(&String, &session::KeyBinding)>,
-    ) = session
-        .key_bindings
-        .iter()
-        .filter_map(|kb| kb.display.as_ref().map(|d| (d, kb)))
-        .partition(|(_, kb)| kb.modes.contains(&Mode::Normal));
+    let (normal_kbs, visual_kbs) = session.key_bindings.get_key_bindings();
 
     let mut line = (0..(session.height as usize - self::LINE_HEIGHT as usize * 4))
         .rev()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,56 @@ mod gfx;
 #[macro_use]
 pub mod util;
 
+// manual prints a quick reference given default Session parameters
+pub fn manual() -> std::io::Result<String> {
+    use std::io;
+
+    let mut manual: String = String::new();
+
+    let proj_dirs = dirs::ProjectDirs::from("io", "cloudhead", "rx")
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "config directory not found"))?;
+    let base_dirs = dirs::BaseDirs::new()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "home directory not found"))?;
+    let cwd = std::env::current_dir()?;
+    let options = Options {
+        headless: true,
+        ..Default::default()
+    };
+
+    let session = Session::new(1, 1, cwd, ResourceManager::new(), proj_dirs, base_dirs)
+        .with_blank(
+            FileStatus::NoFile,
+            Session::DEFAULT_VIEW_W,
+            Session::DEFAULT_VIEW_H,
+        )
+        .init(options.source.clone())?;
+
+    &manual.push_str(&format!("rx v{}: quick reference\n", crate::VERSION));
+
+    let session_kbs = session.key_bindings;
+    let (normal_kbs, visual_kbs) = session_kbs.get_key_bindings();
+
+    // colour the header? Windows versions before Linux subshell update doesn't support ANSI
+    &manual.push_str("\nNORMAL MODE\n\n");
+    for (display, kb) in normal_kbs.iter() {
+        &manual.push_str(&format!("{:<36} {}\n", display, kb.command));
+    }
+
+    &manual.push_str("\nVISUAL MODE\n\n");
+    for (display, kb) in visual_kbs.iter() {
+        &manual.push_str(&format!("{:<36} {}\n", display, kb.command));
+    }
+
+    &manual.push_str("\nCOMMAND MODE\n\n");
+    for (key, def, _) in cmd::Commands::default().iter() {
+        &manual.push_str(&format!(":{:<36} {}\n", key, def));
+    }
+
+    manual.push_str(session::SETTINGS);
+
+    Ok(manual)
+}
+
 use cmd::Value;
 use event::Event;
 use execution::{DigestMode, Execution, ExecutionMode, GifMode};

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ OPTIONS
 
     -v                   Verbose mode
     -u <script>          Use the commands in <script> for initialization
+    -m --man             Prints the `:help` command to the terminal
 
     --record <dir>       Record user input to a directory
     --replay <dir>       Replay user input from a directory
@@ -46,6 +47,11 @@ fn execute(mut args: pico_args::Arguments) -> Result<(), Box<dyn std::error::Err
 
     if args.contains(["-V", "--version"]) {
         println!("rx v{}", rx::VERSION);
+        return Ok(());
+    }
+
+    if args.contains(["-m", "--man"]) {
+        println!("{}", rx::manual()?);
         return Ok(());
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -564,6 +564,13 @@ impl KeyBindings {
     pub fn iter(&self) -> std::slice::Iter<'_, KeyBinding> {
         self.elems.iter()
     }
+
+    /// Return tuple of normal mode and visual mode key bindings
+    pub fn get_key_bindings(&self) -> (Vec<(&String, &KeyBinding)>, Vec<(&String, &KeyBinding)>) {
+        self.iter()
+            .filter_map(|kb| kb.display.as_ref().map(|d| (d, kb)))
+            .partition(|(_, kb)| kb.modes.contains(&Mode::Normal))
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1165,6 +1172,14 @@ impl Session {
             .iter()
             .map(|(_, help, parser)| format!(":{:<36} {}", parser.to_string(), help))
             .collect()
+    }
+
+    /// Return tuple of normal mode and visual mode key bindings
+    pub fn get_key_bindings(&self) -> (Vec<(&String, &KeyBinding)>, Vec<(&String, &KeyBinding)>) {
+        self.key_bindings
+            .iter()
+            .filter_map(|kb| kb.display.as_ref().map(|d| (d, kb)))
+            .partition(|(_, kb)| kb.modes.contains(&Mode::Normal))
     }
 
     ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
* I found it easier to print the `:help` drawing to a stdout/vim buffer when learning the keybindings
* having a dedicated cheatsheet was easier than constantly typing `:help` and panning around (zoom multiplier was around than 2.0)
* apologies for naive implementation I am not familiar with the `Parser` object, there's likely a better way to implement this
* added `:h` shorthand alias (same as vim)