### PR TITLE
Implement selection flipping

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -26,8 +26,8 @@ pub enum Op {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Flip {
-	Horizontal,
-	Vertical,
+    Horizontal,
+    Vertical,
 }
 
 /// User command. Most of the interactions available to

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -25,7 +25,7 @@ pub enum Op {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum Flip {
+pub enum Axis {
     Horizontal,
     Vertical,
 }
@@ -96,7 +96,7 @@ pub enum Command {
     SelectionFill(Option<Rgba8>),
     SelectionErase,
     SelectionJump(Direction),
-    SelectionFlip(Flip),
+    SelectionFlip(Axis),
 
     // Settings
     Set(String, Value),
@@ -228,8 +228,8 @@ impl fmt::Display for Command {
                 write!(f, "Move selection backward by one frame")
             }
             Self::SelectionErase => write!(f, "Erase selection contents"),
-            Self::SelectionFlip(Flip::Horizontal) => write!(f, "Flip selection horizontally"),
-            Self::SelectionFlip(Flip::Vertical) => write!(f, "Flip selection vertically"),
+            Self::SelectionFlip(Axis::Horizontal) => write!(f, "Flip selection horizontally"),
+            Self::SelectionFlip(Axis::Vertical) => write!(f, "Flip selection vertically"),
             Self::PaintColor(_, x, y) => write!(f, "Paint {:2},{:2}", x, y),
             _ => write!(f, "..."),
         }
@@ -980,8 +980,8 @@ impl Default for Commands {
             .command("selection/flip", "Flip selection", |p| {
                 p.then(word().label("h[orizontal]/v[ertical]"))
                     .try_map(|(_, t)| match t.as_str() {
-                        "horizontal" | "h" => Ok(Command::SelectionFlip(Flip::Horizontal)),
-                        "vertical" | "v" => Ok(Command::SelectionFlip(Flip::Vertical)),
+                        "horizontal" | "x" => Ok(Command::SelectionFlip(Axis::Horizontal)),
+                        "vertical" | "y" => Ok(Command::SelectionFlip(Axis::Vertical)),
                         _ => Err(format!("unknown direction {:?}", t)),
                     })
             })

--- a/src/gl/mod.rs
+++ b/src/gl/mod.rs
@@ -1,4 +1,4 @@
-use crate::cmd::Flip;
+use crate::cmd::Axis;
 use crate::draw;
 use crate::execution::Execution;
 use crate::font::TextBatch;
@@ -1081,7 +1081,7 @@ impl Renderer {
                     }
 
                     match dir {
-                        Flip::Vertical => {
+                        Axis::Vertical => {
                             let len = pixels.len();
 
                             let (front, back) = pixels.split_at_mut(len / 2);
@@ -1092,7 +1092,7 @@ impl Renderer {
                                 front_row.swap_with_slice(back_row);
                             }
                         }
-                        Flip::Horizontal => {
+                        Axis::Horizontal => {
                             pixels
                                 .chunks_exact_mut(w as usize)
                                 .for_each(|row| row.reverse());

--- a/src/gl/mod.rs
+++ b/src/gl/mod.rs
@@ -1,3 +1,4 @@
+use crate::cmd::Flip;
 use crate::draw;
 use crate::execution::Execution;
 use crate::font::TextBatch;
@@ -10,7 +11,6 @@ use crate::util;
 use crate::view::layer::{FrameRange, LayerId};
 use crate::view::{ViewId, ViewOp, ViewState};
 use crate::{data, data::Assets, image};
-use crate::cmd::Flip;
 
 use nonempty::NonEmpty;
 
@@ -1091,9 +1091,11 @@ impl Renderer {
                             {
                                 front_row.swap_with_slice(back_row);
                             }
-                        },
+                        }
                         Flip::Horizontal => {
-                            pixels.chunks_exact_mut(w as usize).for_each(|row| row.reverse());
+                            pixels
+                                .chunks_exact_mut(w as usize)
+                                .for_each(|row| row.reverse());
                         }
                     }
 

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -45,9 +45,10 @@ impl Palette {
         let cellsize = self.cellsize as i32;
         let size = self.size() as i32;
         let height = self.height as i32;
+        let columns = (self.size() as f32 / self.height as f32).ceil() as i32;
 
         let width = if size > height {
-            cellsize * 2
+            cellsize * columns
         } else {
             cellsize
         };
@@ -61,7 +62,7 @@ impl Palette {
         x /= cellsize;
         y /= cellsize;
 
-        let index = y + x * height;
+        let index = y + x * (height / cellsize);
 
         self.hover = if index < size {
             // We index from the back because the palette is reversed

--- a/src/session.rs
+++ b/src/session.rs
@@ -3250,9 +3250,6 @@ impl Session {
                         self.selection = Some(Selection::from(s));
                         self.switch_mode(Mode::Visual(VisualState::Pasting));
                     }
-                    // I think its handy to flip in place for now, hence these commands
-                    // 1., 2. prevent overlap and paste
-                    // 3.     preserve location so you can flip repeatedly w/ hotkey
                     self.command(Command::SelectionErase);
                     self.command(Command::SelectionPaste);
                     self.command(Command::Mode(Mode::Visual(VisualState::Selecting {

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,7 +1,7 @@
 ///! Session
 use crate::autocomplete::FileCompleter;
 use crate::brush::*;
-use crate::cmd::{self, Command, CommandLine, KeyMapping, Op, Value, Flip};
+use crate::cmd::{self, Command, CommandLine, Flip, KeyMapping, Op, Value};
 use crate::color;
 use crate::data;
 use crate::event::{Event, TimedEvent};
@@ -3263,7 +3263,9 @@ impl Session {
                 // 3.     preserve location so you can flip repeatedly w/ hotkey
                 self.command(Command::SelectionErase);
                 self.command(Command::SelectionPaste);
-                self.command(Command::Mode(Mode::Visual(VisualState::Selecting { dragging: false })));
+                self.command(Command::Mode(Mode::Visual(VisualState::Selecting {
+                    dragging: false,
+                })));
             }
             Command::SelectionCut => {
                 // To mimick the behavior of `vi`, we yank the selection

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,7 +1,7 @@
 ///! Session
 use crate::autocomplete::FileCompleter;
 use crate::brush::*;
-use crate::cmd::{self, Command, CommandLine, KeyMapping, Op, Value};
+use crate::cmd::{self, Command, CommandLine, KeyMapping, Op, Value, Flip};
 use crate::color;
 use crate::data;
 use crate::event::{Event, TimedEvent};
@@ -2023,6 +2023,27 @@ impl Session {
         None
     }
 
+    /// Flip the selection.
+    fn flip_selection(&mut self, dir: Flip) -> Option<Rect<i32>> {
+        if let (Mode::Visual(VisualState::Selecting { .. }), Some(s)) = (self.mode, self.selection)
+        {
+            let v = self.active_view_mut();
+            let s = s.abs().bounds();
+
+            if s.intersects(v.bounds()) {
+                let s = s.intersection(v.bounds());
+
+                v.flip(s, dir);
+
+                self.selection = Some(Selection::from(s));
+                self.switch_mode(Mode::Visual(VisualState::Pasting));
+
+                return Some(s);
+            }
+        }
+        None
+    }
+
     fn undo(&mut self, id: ViewId) {
         self.restore_view_snapshot(id, Direction::Backward);
     }
@@ -3237,6 +3258,15 @@ impl Session {
             }
             Command::SelectionYank => {
                 self.yank_selection();
+            }
+            Command::SelectionFlip(dir) => {
+                self.flip_selection(dir);
+                // I think its handy to flip in place for now, hence these commands
+                // 1., 2. prevent overlap and paste
+                // 3.     preserve location so you can flip repeatedly w/ hotkey
+                self.command(Command::SelectionErase);
+                self.command(Command::SelectionPaste);
+                self.command(Command::Mode(Mode::Visual(VisualState::Selecting { dragging: false })));
             }
             Command::SelectionCut => {
                 // To mimick the behavior of `vi`, we yank the selection

--- a/src/view.rs
+++ b/src/view.rs
@@ -7,6 +7,7 @@ use crate::resources::EditId;
 use crate::session::{Session, SessionCoords};
 use crate::util;
 use crate::view::layer::{FrameRange, Layer, LayerId};
+use crate::cmd::Flip;
 
 use rgx::kit::Animation;
 use rgx::kit::Rgba8;
@@ -160,6 +161,8 @@ pub enum ViewOp {
     Clear(Rgba8),
     /// Yank the given area into the paste buffer.
     Yank(LayerId, Rect<i32>),
+    /// Flips a given area horizontally or vertically.
+    Flip(LayerId, Rect<i32>, Flip),
     /// Blit the paste buffer into the given area.
     Paste(Rect<i32>),
     /// Resize the view.
@@ -401,6 +404,10 @@ impl View {
     pub fn yank(&mut self, area: Rect<i32>) {
         self.ops.push(ViewOp::Yank(self.active_layer_id, area));
     }
+
+	pub fn flip(&mut self, area: Rect<i32>, dir: Flip) {
+		self.ops.push(ViewOp::Flip(self.active_layer_id, area, dir));
+	}
 
     pub fn paste(&mut self, area: Rect<i32>) {
         self.ops.push(ViewOp::Paste(area));

--- a/src/view.rs
+++ b/src/view.rs
@@ -3,11 +3,11 @@ pub mod path;
 
 pub use path::{Format, Path};
 
+use crate::cmd::Flip;
 use crate::resources::EditId;
 use crate::session::{Session, SessionCoords};
 use crate::util;
 use crate::view::layer::{FrameRange, Layer, LayerId};
-use crate::cmd::Flip;
 
 use rgx::kit::Animation;
 use rgx::kit::Rgba8;
@@ -405,9 +405,9 @@ impl View {
         self.ops.push(ViewOp::Yank(self.active_layer_id, area));
     }
 
-	pub fn flip(&mut self, area: Rect<i32>, dir: Flip) {
-		self.ops.push(ViewOp::Flip(self.active_layer_id, area, dir));
-	}
+    pub fn flip(&mut self, area: Rect<i32>, dir: Flip) {
+        self.ops.push(ViewOp::Flip(self.active_layer_id, area, dir));
+    }
 
     pub fn paste(&mut self, area: Rect<i32>) {
         self.ops.push(ViewOp::Paste(area));

--- a/src/view.rs
+++ b/src/view.rs
@@ -3,7 +3,7 @@ pub mod path;
 
 pub use path::{Format, Path};
 
-use crate::cmd::Flip;
+use crate::cmd::Axis;
 use crate::resources::EditId;
 use crate::session::{Session, SessionCoords};
 use crate::util;
@@ -162,7 +162,7 @@ pub enum ViewOp {
     /// Yank the given area into the paste buffer.
     Yank(LayerId, Rect<i32>),
     /// Flips a given area horizontally or vertically.
-    Flip(LayerId, Rect<i32>, Flip),
+    Flip(LayerId, Rect<i32>, Axis),
     /// Blit the paste buffer into the given area.
     Paste(Rect<i32>),
     /// Resize the view.
@@ -405,7 +405,7 @@ impl View {
         self.ops.push(ViewOp::Yank(self.active_layer_id, area));
     }
 
-    pub fn flip(&mut self, area: Rect<i32>, dir: Flip) {
+    pub fn flip(&mut self, area: Rect<i32>, dir: Axis) {
         self.ops.push(ViewOp::Flip(self.active_layer_id, area, dir));
     }
 


### PR DESCRIPTION
Hi,
this is my humble attempt at implementing the functionality to flip a selection. It was once again a pleasant experience as I really like the structure of the code, but I'm not sure if I'm doing it "idiomatically".

Here is a demonstration of how it looks:
![flip.gif](https://raw.githubusercontent.com/luciusmagn/rx/media/flip.gif)
(yea, the colors are screwed because it's a gif, here's a webm for more pleasant viewing -> [flip.webm](https://raw.githubusercontent.com/luciusmagn/rx/media/flip.webm))

This is what I did for these changes:

1. create a command `selection/flip` which takes one argument of direction, valid values are `h` or `horizontal` and `v` or `vertical`.
2. then I created a `ViewOp` for flip and went to `gl/mod.rs` to create an implementation. It's pretty much a yank, which also takes direction as an argument and then flips the pixels accordingly
3. In session.rs, I added appropriate functions taking yank as example. To allow possibly doing a bunch of flips with a hotkey, I figured the easiest would be doing it in the place of selection, so I did this:

```rust
            Command::SelectionFlip(dir) => {
                self.flip_selection(dir);
                // I think its handy to flip in place for now, hence these commands
                // 1., 2. prevent overlap and paste
                // 3.     preserve location so you can flip repeatedly w/ hotkey
                self.command(Command::SelectionErase);
                self.command(Command::SelectionPaste);
                self.command(Command::Mode(Mode::Visual(VisualState::Selecting { dragging: false })));
            }
```

I'm really unsure if this is the correct way to do it, so I am sorry if I did something wrong, haha :sweat_smile: 