### PR TITLE
fix for users with keyboards that have ? as shift-, and : as shift-.

### DIFF
--- a/src/palette.rs
+++ b/src/palette.rs
@@ -45,9 +45,10 @@ impl Palette {
         let cellsize = self.cellsize as i32;
         let size = self.size() as i32;
         let height = self.height as i32;
+        let columns = (self.size() as f32 / self.height as f32).ceil() as i32;
 
         let width = if size > height {
-            cellsize * 2
+            cellsize * columns
         } else {
             cellsize
         };
@@ -61,7 +62,7 @@ impl Palette {
         x /= cellsize;
         y /= cellsize;
 
-        let index = y + x * height;
+        let index = y + x * (height / cellsize);
 
         self.hover = if index < size {
             // We index from the back because the palette is reversed

--- a/src/session.rs
+++ b/src/session.rs
@@ -497,6 +497,20 @@ impl Default for KeyBindings {
                     display: Some("?".to_string()),
                 },
                 KeyBinding {
+                    modes: vec![Mode::Normal, Mode::Help],
+                    modifiers: ModifiersState {
+                        shift: true,
+                        ctrl: false,
+                        alt: false,
+                        meta: false,
+                    },
+                    key: platform::Key::Comma,
+                    state: InputState::Pressed,
+                    command: Command::Mode(Mode::Help),
+                    is_toggle: false,
+                    display: Some("?".to_string()),
+                },
+                KeyBinding {
                     modes: vec![
                         Mode::Normal,
                         Mode::Visual(VisualState::Pasting),
@@ -509,6 +523,24 @@ impl Default for KeyBindings {
                         meta: false,
                     },
                     key: platform::Key::Semicolon,
+                    state: InputState::Pressed,
+                    command: Command::Mode(Mode::Command),
+                    is_toggle: false,
+                    display: Some(":".to_string()),
+                },
+                KeyBinding {
+                    modes: vec![
+                        Mode::Normal,
+                        Mode::Visual(VisualState::Pasting),
+                        Mode::Visual(VisualState::selecting()),
+                    ],
+                    modifiers: ModifiersState {
+                        shift: true,
+                        ctrl: false,
+                        alt: false,
+                        meta: false,
+                    },
+                    key: platform::Key::Period,
                     state: InputState::Pressed,
                     command: Command::Mode(Mode::Command),
                     is_toggle: false,


### PR DESCRIPTION
Hi, I'm making this PR not with the intetion for it to be merged (because it doesn't really solve the problem) but as a temporary solution to users with keyboard layouts that have question mark as shift-comma and colon as shift-period, for example the Czech QWERTZ layout.

I'm just putting this out there so people with the issue can find a quick solution here and merge from my fork rather than repeating the issue.

Kinda solves #83 for me and other users with similar keyboard layouts.