### PR TITLE
Command to add a gradient to palette. 

### DIFF
--- a/src/palette.rs
+++ b/src/palette.rs
@@ -30,6 +30,25 @@ impl Palette {
         }
     }
 
+    pub fn gradient(&mut self, colorstart: Rgba8, colorend: Rgba8, number: usize) {
+        fn blend_component(start: u8, end: u8, coef: f32) -> u8 {
+            (start as f32 * (1.0 - coef) + end as f32 * coef).round() as u8
+        }
+
+        let step: f32 = 1.0 / ((number - 1) as f32);
+        for i in 0..number {
+            let coef = i as f32 * step;
+            let color: Rgba8 = Rgba8 {
+                r: blend_component(colorstart.r, colorend.r, coef),
+                g: blend_component(colorstart.g, colorend.g, coef),
+                b: blend_component(colorstart.b, colorend.b, coef),
+                a: blend_component(colorstart.a, colorend.a, coef),
+            };
+
+            self.colors.push(color);
+        }
+    }
+
     pub fn clear(&mut self) {
         self.colors.clear();
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -2801,6 +2801,10 @@ impl Session {
             Command::PaletteClear => {
                 self.palette.clear();
             }
+            Command::PaletteGradient(colorstart, colorend, steps) => {
+                self.palette.gradient(colorstart, colorend, steps);
+                self.center_palette();
+            }
             Command::PaletteSort => {
                 // Sort by total luminosity. This is pretty lame, but it's
                 // something to work with.


### PR DESCRIPTION
I am somewhat new to Rust, so lots of possible mistakes in here. 

Anyway, this PR adds a command to add a gradient to the palette using:
 `p/gradient <color_start> <color _end> <steps>` 
which creates `steps` colors in the palette starting with `color_start` ending with `color_end`.

Question is : it currently adds all color, whether it is already present in palette or not. Should it ? `p/add` does not, but it adds a single color. I cannot really decide on this one. 

It misses test, I just have no time to learn how to test in rust.
I noticed that similar function tend to be in `session.rs`. I put my logic in `palette.rs` as it is palette manipulation, I find it more legible, but it may not be the right way.