### PR TITLE
Faster FloodFill

### DIFF
--- a/src/flood.rs
+++ b/src/flood.rs
@@ -1,78 +1,178 @@
-use crate::view::layer::LayerCoords;
-use crate::view::{Snapshot, View, ViewResource};
+use crate::view::layer::{LayerCoords};
+use crate::view::{View, ViewResource};
 use rgx::color::Rgba8;
 use rgx::kit::shape2d::{Fill, Rotation, Shape, Stroke};
 use rgx::kit::ZDepth;
+use rgx::math::Point2;
 use rgx::rect::Rect;
 
-pub fn flood_fill(
-    view: &View<ViewResource>,
-    starting_point: LayerCoords<u32>,
-    replacement_color: Rgba8,
-) -> Option<Vec<Shape>> {
-    let (snapshot, pixels) = view.current_snapshot(view.active_layer_id)?;
-    let mut canvas = pixels.clone().into_rgba8();
-    let bounds = snapshot.extent.rect();
-    let target_color = get_color(snapshot, &mut canvas, starting_point)?.clone();
+struct Grid {
+    pixels: Vec<Rgba8>,
+    pub width: usize,
+    pub height: usize,
+}
 
-    if target_color == replacement_color {
-        return None;
+impl Grid {
+    pub fn new(pixels: Vec<Rgba8>, width: usize, height: usize) -> Grid {
+        Grid {
+            pixels,
+            width,
+            height,
+        }
     }
 
-    let mut points = Vec::new();
-    let mut queue = vec![starting_point];
+    pub fn get(&self, x: usize, y: usize) -> Option<&Rgba8> {
+        if x < self.width && y < self.height {
+            self.pixels.get(x + y * self.width)
+        } else {
+            None
+        }
+    }
 
-    while let Some(point) = queue.pop() {
-        if let Some(c) = get_color(snapshot, &mut canvas, point) {
-            if *c == target_color {
-                *c = replacement_color;
-                points.push((point, replacement_color));
-                queue.extend(neighbors(point, bounds));
+    pub fn get_mut(&mut self, x: usize, y: usize) -> Option<&mut Rgba8> {
+        if x < self.width && y < self.height {
+            self.pixels.get_mut(x + y * self.width)
+        } else {
+            None
+        }
+    }
+}
+
+pub struct FloodFiller {
+    grid: Grid,
+    replacement_color: Rgba8,
+    target_color: Rgba8,
+    rects: Vec<(Rect<f32>, Rgba8)>,
+    stack: Vec<Point2<usize>>,
+}
+
+impl FloodFiller {
+    pub fn new(
+        view: &View<ViewResource>,
+        starting_point: LayerCoords<f32>,
+        replacement_color: Rgba8,
+    ) -> Option<FloodFiller> {
+        let (snapshot, pixels) = view.current_snapshot(view.active_layer_id)?;
+        let bounds = snapshot.extent.rect();
+        let grid = Grid::new(
+            pixels.clone().into_rgba8(),
+            bounds.width() as usize,
+            bounds.height() as usize,
+        );
+
+        let starting_point = Point2::new(
+            starting_point.x as usize,
+            grid.height - starting_point.y as usize - 1,
+        );
+
+        let target_color = grid.get(starting_point.x, starting_point.y)?.clone();
+        Some(FloodFiller {
+            grid,
+            target_color,
+            replacement_color,
+            rects: Vec::new(),
+            stack: vec![starting_point],
+        })
+    }
+
+    fn push_rect(&mut self, x: usize, y: usize, w: usize, h: usize, color: Rgba8) {
+        self.rects.push((
+            Rect::new(
+                x as f32,
+                (self.grid.height - y - 1) as f32,
+                (x + w) as f32,
+                (self.grid.height - y - 1 + h) as f32,
+            ),
+            color,
+        ));
+    }
+
+    fn try_set_at(&mut self, x: usize, y: usize) -> bool {
+        match self.grid.get_mut(x, y) {
+            Some(c) => {
+                if *c != self.target_color {
+                    false
+                } else {
+                    *c = self.replacement_color;
+                    true
+                }
+            }
+            None => false,
+        }
+    }
+
+    fn push_on_change(&mut self, x: usize, y: usize, edge: &mut bool) {
+        if let Some(c) = self.grid.get(x, y) {
+            if *c == self.target_color {
+                if *edge {
+                    self.stack.push(Point2::new(x, y));
+                    *edge = false;
+                }
+            } else {
+                *edge = true;
             }
         }
     }
 
-    Some(to_shapes(points))
+    fn look_above_below(&mut self, x: usize, y: usize, up: &mut bool, down: &mut bool) {
+        if y > 0 {
+            self.push_on_change(x, y - 1, up);
+        }
+
+        if y < self.grid.height - 1 {
+            self.push_on_change(x, y + 1, down);
+        }
+    }
+
+    pub fn run(mut self) -> Option<Vec<Shape>> {
+        if self.target_color == self.replacement_color {
+            return None;
+        }
+
+        while let Some(p) = self.stack.pop() {
+            let mut min_x = p.x;
+            let mut max_x = p.x;
+            let mut up = true;
+            let mut down = true;
+
+            for x in p.x..=self.grid.width {
+                max_x = x;
+                if !self.try_set_at(x, p.y) {
+                    break;
+                }
+                self.look_above_below(x, p.y, &mut up, &mut down);
+            }
+
+            up = p.y > 0 && self.grid.get(p.x, p.y - 1) != Some(&self.target_color);
+            down = p.y < self.grid.height - 1
+                && self.grid.get(p.x, p.y + 1) != Some(&self.target_color);
+
+            for x in (0..p.x).rev() {
+                min_x = x;
+                if !self.try_set_at(x, p.y) {
+                    min_x += 1;
+                    break;
+                }
+                self.look_above_below(x, p.y, &mut up, &mut down);
+            }
+
+            self.push_rect(min_x, p.y, max_x - min_x, 1, self.replacement_color);
+        }
+
+        Some(to_shapes(self.rects))
+    }
 }
 
-fn get_color<'a>(
-    snapshot: &Snapshot,
-    canvas: &'a mut Vec<Rgba8>,
-    point: LayerCoords<u32>,
-) -> Option<&'a mut Rgba8> {
-    let idx = snapshot.layer_coord_to_index(point)?;
-    canvas.get_mut(idx)
-}
-
-fn to_shapes(points: Vec<(LayerCoords<u32>, Rgba8)>) -> Vec<Shape> {
-    let mut rects = Vec::with_capacity(points.len());
-    for (it, color) in points {
-        let x = it.x as f32;
-        let y = it.y as f32;
+fn to_shapes(input: Vec<(Rect<f32>, Rgba8)>) -> Vec<Shape> {
+    let mut rects = Vec::with_capacity(input.len());
+    for (rect, color) in input {
         rects.push(Shape::Rectangle(
-            Rect::new(x, y, x + 1.0, y + 1.0),
+            rect,
             ZDepth::default(),
             Rotation::ZERO,
             Stroke::NONE,
-            Fill::Solid(color.into()),
+            Fill::solid(color),
         ));
     }
     rects
-}
-
-fn neighbors(p: LayerCoords<u32>, bounds: Rect<u32>) -> Vec<LayerCoords<u32>> {
-    let mut v = Vec::with_capacity(4);
-    if p.x > bounds.x1 {
-        v.push(LayerCoords::new(p.x - 1, p.y))
-    }
-    if p.x < bounds.x2 - 1 {
-        v.push(LayerCoords::new(p.x + 1, p.y))
-    }
-    if p.y > bounds.y1 {
-        v.push(LayerCoords::new(p.x, p.y - 1))
-    }
-    if p.y < bounds.y2 - 1 {
-        v.push(LayerCoords::new(p.x, p.y + 1))
-    }
-    v
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -2206,12 +2206,17 @@ impl Session {
                                 }
                                 Tool::Pan(_) => {}
                                 Tool::FloodFill => {
+                                    let start_time = time::Instant::now();
                                     let filler =
                                         FloodFiller::new(self.active_view(), p.into(), self.fg);
                                     if let Some(shapes) = filler.and_then(|f| f.run()) {
                                         self.effects.push(Effect::ViewPaintFinal(shapes));
                                         self.active_view_mut().touch_layer();
                                     }
+                                    debug!(
+                                        "flood fill in: {:?} ms",
+                                        (time::Instant::now() - start_time).as_millis()
+                                    );
                                 }
                             },
                             Mode::Command => {

--- a/src/session.rs
+++ b/src/session.rs
@@ -2213,10 +2213,7 @@ impl Session {
                                         self.effects.push(Effect::ViewPaintFinal(shapes));
                                         self.active_view_mut().touch_layer();
                                     }
-                                    debug!(
-                                        "flood fill in: {:?} ms",
-                                        (time::Instant::now() - start_time).as_millis()
-                                    );
+                                    debug!("flood fill in: {:?}", start_time.elapsed());
                                 }
                             },
                             Mode::Command => {

--- a/src/session.rs
+++ b/src/session.rs
@@ -6,7 +6,7 @@ use crate::color;
 use crate::data;
 use crate::event::{Event, TimedEvent};
 use crate::execution::{DigestMode, DigestState, Execution};
-use crate::flood::flood_fill;
+use crate::flood::FloodFiller;
 use crate::hashmap;
 use crate::palette::*;
 use crate::platform::{self, InputState, Key, KeyboardInput, LogicalSize, ModifiersState};
@@ -2206,9 +2206,9 @@ impl Session {
                                 }
                                 Tool::Pan(_) => {}
                                 Tool::FloodFill => {
-                                    if let Some(shapes) =
-                                        flood_fill(self.active_view(), p.into(), self.fg)
-                                    {
+                                    let filler =
+                                        FloodFiller::new(self.active_view(), p.into(), self.fg);
+                                    if let Some(shapes) = filler.and_then(|f| f.run()) {
                                         self.effects.push(Effect::ViewPaintFinal(shapes));
                                         self.active_view_mut().touch_layer();
                                     }


### PR DESCRIPTION
The flood fill algorithm introduced in https://github.com/cloudhead/rx/pull/100 was simple, but not very fast. I don't know how common it is for people to use `rx` to edit large-ish images, but I figured it'd be worth taking a little extra time to optimize.
In release mode, this algorithm fills a 1024x1024 canvas in ~12ms, vs ~210ms for old algorithm