### PR TITLE
Add ability to draw "angle snapped" lines

### DIFF
--- a/src/brush.rs
+++ b/src/brush.rs
@@ -28,8 +28,6 @@ pub enum BrushState {
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Debug)]
 pub enum LineDirection {
     Free,
-    Horizontal,
-    Vertical,
     AngleSnap(u32),
 }
 
@@ -37,8 +35,6 @@ impl fmt::Display for LineDirection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Free => "free".fmt(f),
-            Self::Horizontal => "horizontal".fmt(f),
-            Self::Vertical => "vertical".fmt(f),
             Self::AngleSnap(angle) => write!(f, "{} degree snap", angle),
         }
     }
@@ -201,8 +197,6 @@ impl Brush {
 
             let end = match direction {
                 LineDirection::Free => self.curr,
-                LineDirection::Horizontal => Point2::new(self.curr.x, start.y),
-                LineDirection::Vertical => Point2::new(start.x, self.curr.y),
                 LineDirection::AngleSnap(snap) => {
                     let snap_rad = snap as f32 * PI / 180.0;
                     let curr: Vector2<f32> = self.curr.map(|x| x as f32).into();

--- a/src/brush.rs
+++ b/src/brush.rs
@@ -41,7 +41,10 @@ pub enum BrushMode {
     /// X-Ray mode.
     XRay,
     /// Confine stroke to a straight line from the starting point
-    Line(Option<u32>),
+    Line(
+        /// snap angle (degrees)
+        Option<u32>,
+    ),
 }
 
 impl fmt::Display for BrushMode {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,7 +5,7 @@ use directories as dirs;
 
 use rgx::kit::Rgba8;
 
-use crate::brush::{BrushMode, LineDirection};
+use crate::brush::BrushMode;
 use crate::platform;
 use crate::session::{Direction, Mode, VisualState};
 
@@ -169,7 +169,7 @@ impl Parse for BrushMode {
                     "ysym" => Ok((BrushMode::YSym, p)),
                     "xray" => Ok((BrushMode::XRay, p)),
                     "line" => optional(whitespace())
-                        .then(param())
+                        .then(optional(natural()))
                         .parse(p)
                         .map(|((_, line_mode), p)| (BrushMode::Line(line_mode), p)),
                     mode => Err((
@@ -180,18 +180,6 @@ impl Parse for BrushMode {
             },
             "<mode>",
         )
-    }
-}
-
-impl Parse for LineDirection {
-    fn parser() -> Parser<Self> {
-        choice(vec![
-            whitespace()
-                .then(integer())
-                .map(|(_, angle)| Self::AngleSnap(angle))
-                .label("snap"),
-            succeed(Self::Free).label("free"),
-        ])
     }
 }
 
@@ -230,11 +218,6 @@ pub fn setting() -> Parser<String> {
 
 pub fn tuple<O>(x: Parser<O>, y: Parser<O>) -> Parser<(O, O)> {
     x.skip(whitespace()).then(y)
-}
-
-/// A parser which always succeeds with the provided value
-pub fn succeed<O: Copy>(value: O) -> Parser<O> {
-    Parser::new(move |s| Ok((value, s)), "")
 }
 
 #[cfg(test)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -171,7 +171,7 @@ impl Parse for BrushMode {
                     "line" => optional(whitespace())
                         .then(optional(natural()))
                         .parse(p)
-                        .map(|((_, line_mode), p)| (BrushMode::Line(line_mode), p)),
+                        .map(|((_, snap), p)| (BrushMode::Line(snap), p)),
                     mode => Err((
                         memoir::result::Error::new(format!("unknown brush mode '{}'", mode)),
                         input,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -186,11 +186,9 @@ impl Parse for BrushMode {
 impl Parse for LineDirection {
     fn parser() -> Parser<Self> {
         choice(vec![
-            string("v").value(Self::Vertical).label("vertical"),
-            string("h").value(Self::Horizontal).label("horizontal"),
-            string("s")
-                .then(optional(whitespace()).then(integer()))
-                .map(|(_, (_, angle))| Self::AngleSnap(angle))
+            whitespace()
+                .then(integer())
+                .map(|(_, angle)| Self::AngleSnap(angle))
                 .label("snap"),
             succeed(Self::Free).label("free"),
         ])

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -188,6 +188,10 @@ impl Parse for LineDirection {
         choice(vec![
             string("v").value(Self::Vertical).label("vertical"),
             string("h").value(Self::Horizontal).label("horizontal"),
+            string("s")
+                .then(optional(whitespace()).then(integer()))
+                .map(|(_, (_, angle))| Self::AngleSnap(angle))
+                .label("snap"),
             succeed(Self::Free).label("free"),
         ])
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,6 @@
-use rgx::math::Point2;
+use rgx::math::{Point2, Vector2};
 use rgx::rect::Rect;
+use std::f32::consts::PI;
 
 pub fn clamp(p: &mut Point2<i32>, rect: Rect<i32>) {
     if p.x < rect.x1 {
@@ -47,6 +48,11 @@ pub fn align_u8<T>(data: &[T]) -> &[u8] {
     assert!(tail.is_empty());
 
     body
+}
+
+/// Returns the angle between two vectors, in radians.
+pub fn vector_angle(a: &Vector2<f32>, b: &Vector2<f32>) -> f32 {
+    (a.x - b.x).atan2(b.y - a.y)
 }
 
 #[macro_export]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,5 @@
 use rgx::math::{Point2, Vector2};
 use rgx::rect::Rect;
-use std::f32::consts::PI;
 
 pub fn clamp(p: &mut Point2<i32>, rect: Rect<i32>) {
     if p.x < rect.x1 {


### PR DESCRIPTION
Adds a new parameter to the line mode,`:brush/set line s <angle>`, which causes drawn lines to snap to increments of the given angle. 

https://user-images.githubusercontent.com/1817241/106367265-2ceae300-62f6-11eb-92bb-7de51cf46c71.mov

