### PR TITLE
M1 glfw fix

### DIFF
--- a/src/platform/glfw.rs
+++ b/src/platform/glfw.rs
@@ -24,7 +24,7 @@ pub fn init(
     glfw.window_hint(glfw::WindowHint::Focused(true));
     glfw.window_hint(glfw::WindowHint::RefreshRate(None));
     glfw.window_hint(glfw::WindowHint::ScaleToMonitor(true));
-    glfw.window_hint(glfw::WindowHint::DoubleBuffer(false));
+    glfw.window_hint(glfw::WindowHint::DoubleBuffer(true));
 
     match context {
         GraphicsContext::None => {

--- a/src/platform/glfw.rs
+++ b/src/platform/glfw.rs
@@ -25,7 +25,6 @@ pub fn init(
     glfw.window_hint(glfw::WindowHint::RefreshRate(None));
     glfw.window_hint(glfw::WindowHint::ScaleToMonitor(true));
     glfw.window_hint(glfw::WindowHint::DoubleBuffer(true));
-
     match context {
         GraphicsContext::None => {
             glfw.window_hint(glfw::WindowHint::ClientApi(glfw::ClientApiHint::NoApi));
@@ -51,6 +50,7 @@ pub fn init(
     window.make_current();
     window.set_all_polling(true);
 
+    glfw.set_swap_interval(glfw::SwapInterval::None);
     Ok((
         Window {
             handle: window,


### PR DESCRIPTION
`SwapInterval::Adaptive` may be used to allow lower latency control, though this depends on the `WGL_EXT_swap_control_tear`and `GLX_EXT_swap_control_tear` extensions as per the GLFW docs: https://www.glfw.org/docs/3.0/group__context.html#ga15a5a1ee5b3c2ca6b15ca209a12efd14