### PR TITLE
Avoid crashing when frame has been deleted

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -232,7 +232,7 @@ impl<T> Animation<T> {
     }
 
     pub fn val(&self) -> &T {
-        &self.frames[self.index]
+        &self.frames[self.index % self.len()]
     }
 }
 


### PR DESCRIPTION
The current code has an `(n - 1) / n` chance of crashing when you delete one of `n` frames. It's trivial to trigger the crash by starting `rx` and repeatedly pressing `Return` and then `Backspace` (repeat until crash occurs, it won't take long).