### PR TITLE
Added support for Home/End key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "rx"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrayvec",
  "chrono",

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -602,6 +602,17 @@ impl CommandLine {
         }
     }
 
+    pub fn cursor_back(&mut self) {
+        if self.cursor > 1 {
+            self.cursor = 1;
+            self.autocomplete.invalidate();
+        }
+    }
+
+    pub fn cursor_front(&mut self) {
+        self.cursor = self.input.len();
+    }
+
     pub fn putc(&mut self, c: char) {
         if self.input.len() + c.len_utf8() > self.input.capacity() {
             return;
@@ -1334,6 +1345,19 @@ mod test {
 
         cli.delc();
         assert_eq!(cli.input(), ":e");
+
+        cli.clear();
+        cli.puts(":echo");
+
+        assert_eq!(cli.peek(), None);
+        cli.cursor_back();
+
+        assert_eq!(cli.peek(), Some('e'));
+        assert_eq!(cli.peek_back(), Some(':'));
+
+        cli.cursor_front();
+        assert_eq!(cli.peek(), None);
+        assert_eq!(cli.peek_back(), Some('o'));
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -2286,6 +2286,12 @@ impl Session {
                             platform::Key::Escape => {
                                 self.cmdline_hide();
                             }
+                            platform::Key::Home => {
+                                self.cmdline.cursor_back();
+                            }
+                            platform::Key::End => {
+                                self.cmdline.cursor_front();
+                            }
                             _ => {}
                         }
                     }


### PR DESCRIPTION
- Updated Cargo.lock so that the package version matches that of Cargo.lock (done automatically by cargo)
- When `Home` key is pressed, the cursor moves in front of the first character (after the leading `:`)
- When `End` key is pressed, the cursor moves over the last character
This resolves #75 