### PR TITLE
Example implementation of variables

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -377,6 +377,7 @@ pub enum Value {
     Str(String),
     Ident(String),
     Rgba8(Rgba8),
+    Var(String),
 }
 
 impl Value {
@@ -408,6 +409,13 @@ impl Value {
         panic!("expected {:?} to be a `Rgba8`", self);
     }
 
+    pub fn to_var(&self) -> &str {
+        if let Value::Var(var) = self {
+            return &var;
+        }
+        panic!("expected {:?} to be a `variable`", self);
+    }
+
     pub fn description(&self) -> &'static str {
         match self {
             Self::Bool(_) => "on / off",
@@ -418,6 +426,7 @@ impl Value {
             Self::Str(_) => "string, eg. \"fnord\"",
             Self::Rgba8(_) => "color, eg. #ffff00",
             Self::Ident(_) => "identifier, eg. fnord",
+            Self::Var(_) => "variable, eg. &grid",
         }
     }
 }
@@ -461,6 +470,7 @@ impl fmt::Display for Value {
             Value::Str(s) => s.fmt(f),
             Value::Rgba8(c) => c.fmt(f),
             Value::Ident(i) => i.fmt(f),
+            Value::Var(v) => v.fmt(f),
         }
     }
 }
@@ -468,6 +478,7 @@ impl fmt::Display for Value {
 impl Parse for Value {
     fn parser() -> Parser<Self> {
         let str_val = quoted().map(Value::Str).label("<string>");
+        let var_val = variable().map(Value::Var).label("<variable>");
         let rgba8_val = color().map(Value::Rgba8);
         let u32_tuple_val = tuple::<u32>(natural(), natural()).map(|(x, y)| Value::U32Tuple(x, y));
         let u32_val = natural::<u32>().map(Value::U32);
@@ -488,6 +499,7 @@ impl Parse for Value {
             f64_val,
             bool_val,
             ident_val,
+            var_val,
             str_val,
         ])
         .label("<value>")

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -45,6 +45,13 @@ pub fn scale() -> Parser<u32> {
         .map(|(_, scale)| scale)
 }
 
+pub fn variable() -> Parser<String> {
+    symbol('&')
+        .then(identifier())
+        .label("&<variable>")
+        .map(|(_, variable)| variable)
+}
+
 pub fn path() -> Parser<String> {
     token()
         .map(|input: String| {

--- a/src/session.rs
+++ b/src/session.rs
@@ -2834,13 +2834,19 @@ impl Session {
                     );
                     return;
                 }
-                match self.settings.set(k, v.clone()) {
-                    Err(e) => {
-                        self.message(format!("Error: {}", e), MessageType::Error);
-                    }
-                    Ok(ref old) => {
-                        if old != v {
-                            self.setting_changed(k, old, v);
+                let val = match v {
+                    Value::Var(_) => self.settings.get(v.to_var()).map(|r| r.clone()),
+                    _ => Some(v.clone()),
+                };
+                if let Some(ref v) = val {
+                    match self.settings.set(k, v.clone()) {
+                        Err(e) => {
+                            self.message(format!("Error: {}", e), MessageType::Error);
+                        }
+                        Ok(ref old) => {
+                            if old != v {
+                                self.setting_changed(k, old, v);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Implemented a quick spike of one of the ideas from issue #120. This is a pretty limited example since it only supports using a setting as a variable in a `Set` call. `set grid/color = &background` or similar works with these changes.

Is this a direction worth pursuing? To be useful for #120 it would in the very least need to cover referencing a setting's value in any command (allowing selection movement to be based on grid size). Adding code to each and every command doesn't seem tenable, but I'm fairly sure that mapping over the `cmd` argument in `fn command` (session.rs) and resolving any `Value::var`s would be doable.

Additionally I didn't tackle tuple destructuring support here. I'm thinking the easiest solution would be to allow tuple values to access by index as `&grid/spacing.0` or possibly `&grid/spacing.first`.