### PR TITLE
Handle delete key in cmdline

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -2131,6 +2131,9 @@ impl Session {
                             platform::Key::Backspace => {
                                 self.cmdline_handle_backspace();
                             }
+                            platform::Key::Delete => {
+                                self.cmdline_handle_delete();
+                            }
                             platform::Key::Return => {
                                 self.cmdline_handle_enter();
                             }
@@ -3025,6 +3028,15 @@ impl Session {
     }
 
     fn cmdline_handle_backspace(&mut self) {
+        self.cmdline.delc();
+
+        if self.cmdline.is_empty() {
+            self.cmdline_hide();
+        }
+    }
+
+    fn cmdline_handle_delete(&mut self) {
+        self.cmdline.cursor_forward();
         self.cmdline.delc();
 
         if self.cmdline.is_empty() {


### PR DESCRIPTION
If there is a character after the cursor delete that, otherwise delete the current character.

If the deletion should be only delete the character after the cursor these change must be made:
```rust
    fn cmdline_handle_delete(&mut self) {
        if self.cmdline.cursor_forward().is_some() {
            self.cmdline.delc();
        }

        if self.cmdline.is_empty() {
            self.cmdline_hide();
        }
    }
```