### PR TITLE
Add saveas command

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -2774,6 +2774,19 @@ impl Session {
                     Err(err) => self.message(format!("Error: {}", err), MessageType::Error),
                 }
             }
+            Command::SaveAs(ref path) => {
+                match self.active_view_mut().save_as(&Path::new(path).into()) {
+                    Ok(written) => {
+                        self.message(
+                            format!("\"{}\" {} pixels written", path, written),
+                            MessageType::Info,
+                        );
+                        self.active_view_mut().file_status =
+                            FileStatus::Saved(FileStorage::Single(Path::new(path).into()));
+                    }
+                    Err(err) => self.message(format!("Error: {}", err), MessageType::Error),
+                }
+            }
             Command::WriteFrames(None) => {
                 self.command(Command::WriteFrames(Some(".".to_owned())));
             }


### PR DESCRIPTION
Solves #95  (actually the command is `:saveas` and not `:sav`).
Save view to disk and change its name.
