### PR TITLE
Remove `mutable_borrow_reservation_conflict` allow

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -2678,7 +2678,6 @@ impl Session {
                     }
                 }
             }
-            #[allow(mutable_borrow_reservation_conflict)]
             Command::Toggle(ref k) => match self.settings.get(k) {
                 Some(Value::Bool(b)) => self.command(Command::Set(k.clone(), Value::Bool(!b))),
                 Some(_) => {


### PR DESCRIPTION
```
warning: lint `mutable_borrow_reservation_conflict` has been removed: now allowed, see issue #59159 <https://github.com/rust-lang/rust/issues/59159> for more information
    --> src/session.rs:2681:21
     |
2681 |             #[allow(mutable_borrow_reservation_conflict)]
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: `#[warn(renamed_and_removed_lints)]` on by default

warning: `rx` (lib) generated 1 warning
```

This lint has been removed. See https://github.com/rust-lang/rust/issues/59159.
This removes the allow for this now non-existent lint. 😃 