### PR TITLE
Add status line trimming

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -267,7 +267,7 @@ fn draw_ui(session: &Session, canvas: &mut shape2d::Batch, text: &mut TextBatch)
     if session.settings["ui/status"].is_set() {
         // Active view status
         text.add(
-            &view.status(),
+            &view.status(session.width, MARGIN),
             MARGIN,
             MARGIN + self::LINE_HEIGHT,
             self::TEXT_LAYER,

--- a/src/view.rs
+++ b/src/view.rs
@@ -412,8 +412,21 @@ impl<R> View<R> {
     }
 
     /// Return the file status as a string.
-    pub fn status(&self) -> String {
-        self.file_status.to_string()
+    pub fn status(&self, width: f32, margin: f32) -> String {
+        let mut shortened_status: String = self.file_status.to_string();
+        let pixel_bound: f32 = (width * 0.4) - 32.0;
+        let name_width: i32 = (shortened_status.len() as i32 * 8) + margin as i32;
+        let pixel_diff: i32 = pixel_bound.floor() as i32 - name_width;
+        let midpoint_index: i32 = shortened_status.len() as i32 / 6;
+        let endpoint: i32 = (midpoint_index - 3) - (pixel_diff / 8);
+
+        // If the user makes the window too small, nothing will be replaced and it will just
+        // display the full status
+        if pixel_diff < 0 && midpoint_index > 3 && endpoint < shortened_status.len() as i32 {
+            shortened_status.replace_range((midpoint_index - 3) as usize..endpoint as usize, "...");
+        }
+
+        return shortened_status;
     }
 
     /// Return the view extent.


### PR DESCRIPTION
Fix/basic implementation of #112. Automatically pulls characters from the status string and replaces them with "...". This method does have the downside of showing the full status string if the window is resized small enough, however I presume the average user isn't going to be doing this, so it shouldn't matter.

Important to note that this is not configurable currently, but configurable behavior could be feasibly added on in the future.